### PR TITLE
updated links, updated for errata, expanded actions, added bonus actions/movements/reactions, added cross-referencing

### DIFF
--- a/app/data/action.json
+++ b/app/data/action.json
@@ -4,9 +4,14 @@
   "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#Action",
   "contents": [
     {
-      "name": "Attack",
-      "summary": "Attack with a weapon, or use an Unarmed Strike to damage, grapple, or shove a target within 5 feet.",
+      "name": "Attack (Weapon)",
+      "summary": "Attack with a weapon.",
       "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#AttackAction"
+    },
+    {
+      "name": "Attack (Unarmed Strike)",
+      "summary": "Use an Unarmed Strike to damage, grapple, or shove a target within 5 feet.",
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#UnarmedStrike"
     },
     {
       "name": "Dash",

--- a/app/data/action.json
+++ b/app/data/action.json
@@ -5,7 +5,7 @@
   "contents": [
     {
       "name": "Attack",
-      "summary": "Attack with a weapon or an Unarmed Strike.",
+      "summary": "Attack with a weapon, or use an Unarmed Strike to damage, grapple, or shove a target within 5 feet.",
       "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#AttackAction"
     },
     {

--- a/app/data/action.json
+++ b/app/data/action.json
@@ -60,7 +60,7 @@
     },
     {
       "name": "Utilize",
-      "summary": "Use a nonmagical object.",
+      "summary": "Use a nonmagical object; don or doff a Shield.",
       "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#UtilizeAction"
     }
   ]

--- a/app/data/action.json
+++ b/app/data/action.json
@@ -1,67 +1,67 @@
 {
   "title": "Action",
   "description": "When you do something other than moving or communicating, you typically take an action.",
-  "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#Action",
+  "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#Action",
   "contents": [
     {
       "name": "Attack",
       "summary": "Attack with a weapon or an Unarmed Strike.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#AttackAction"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#AttackAction"
     },
     {
       "name": "Dash",
       "summary": "For the rest of the turn, give yourself extra movement equal to your Speed.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#DashAction"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#DashAction"
     },
     {
       "name": "Disengage",
       "summary": "Your movement doesn’t provoke Opportunity Attack for the rest of the turn.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#DisengageAction"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#DisengageAction"
     },
     {
       "name": "Dodge",
       "summary": "Until the start of your next turn, attack rolls against you have Disadvantage, and you make Dexterity saving throws with Advantage. You lose this benefit if you have the Incapacitated condition or if your Speed is 0.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#DodgeAction"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#DodgeAction"
     },
     {
       "name": "Help",
       "summary": "Help another creature’s ability check or attack roll, or administer first aid.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#HelpAction"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#HelpAction"
     },
     {
       "name": "Hide",
-      "summary": "Make a Dexterity (Stealth) check.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#HideAction"
+      "summary": "Make a DC 15 Dexterity (Stealth) check while Heavily Obscured or behind Three-Quarters or Total Cover and out of an enemy's line of sight. On a success, you have the Invisible condition while hidden. For a creature to find you, it must succeed on a Wisdom (Perception) check using your original Dexterity (Stealth) check as the DC; otherwise, you stop being hidden if you make a sound, make an attack roll, or cast a spell with a Verbal component.",
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#HideAction"
     },
     {
       "name": "Influence",
       "summary": "Make a Charisma (Deception, Intimidation, Performance, or Persuasion) or Wisdom (Animal Handling) check to alter a creature’s attitude.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#InfluenceAction"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#InfluenceAction"
     },
     {
       "name": "Magic",
       "summary": "Cast a spell, use a magic item, or use a magical feature.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#MagicAction"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#MagicAction"
     },
     {
       "name": "Ready",
       "summary": "Prepare to take an action in response to a trigger you define.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#ReadyAction"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#ReadyAction"
     },
     {
       "name": "Search",
       "summary": "Make a Wisdom (Insight, Medicine, Perception, or Survival) check.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#SearchAction"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#SearchAction"
     },
     {
       "name": "Study",
       "summary": "Make an Intelligence (Arcana, History, Investigation, Nature, or Religion) check.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#StudyAction"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#StudyAction"
     },
     {
       "name": "Utilize",
       "summary": "Use a nonmagical object.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#UtilizeAction"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#UtilizeAction"
     }
   ]
 }

--- a/app/data/action.json
+++ b/app/data/action.json
@@ -35,7 +35,7 @@
     },
     {
       "name": "Hide",
-      "summary": "Make a DC 15 Dexterity (Stealth) check while Heavily Obscured or behind Three-Quarters or Total Cover and out of an enemy's line of sight. On a success, you have the Invisible condition while hidden. For a creature to find you, it must succeed on a Wisdom (Perception) check using your original Dexterity (Stealth) check as the DC; otherwise, you stop being hidden if you make a sound, make an attack roll, or cast a spell with a Verbal component.",
+      "summary": "Make a DC 15 Dexterity (Stealth) check while Heavily Obscured or behind Three-Quarters or Total Cover (see Cover) and out of an enemy's line of sight. On a success, you have the Invisible condition while hidden. For a creature to find you, it must succeed on a Wisdom (Perception) check using your original Dexterity (Stealth) check as the DC; otherwise, you stop being hidden if you make a sound, make an attack roll, or cast a spell with a Verbal component.",
       "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#HideAction"
     },
     {

--- a/app/data/areaOfEffect.json
+++ b/app/data/areaOfEffect.json
@@ -1,37 +1,37 @@
 {
   "title": "Area of Effect",
   "description": "The descriptions of many spells and other features specify that they have an area of effect, which typically has one of six shapes.",
-  "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#AreaofEffect",
+  "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#AreaofEffect",
   "contents": [
     {
       "name": "Cone",
       "summary": "A Cone is an area of effect that extends in straight lines from a point of origin in a direction its creator chooses. A Cone’s width at any point along its length is equal to that point’s distance from the point of origin. For example, a Cone is 15 feet wide at a point along its length that is 15 feet from the point of origin. The effect that creates a Cone specifies its maximum length.<br/><br/>A Cone’s point of origin isn’t included in the area of effect unless its creator decides otherwise.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#ConeAreaofEffect"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#ConeAreaofEffect"
     },
     {
       "name": "Cube",
       "summary": "A Cube is an area of effect that extends in straight lines from a point of origin located anywhere on a face of the Cube. The effect that creates a Cube specifies its size, which is the length of each side.<br/><br/>A Cube’s point of origin isn’t included in the area of effect unless its creator decides otherwise.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#CubeAreaofEffect"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#CubeAreaofEffect"
     },
     {
       "name": "Cylinder",
       "summary": "A Cylinder is an area of effect that extends in straight lines from a point of origin located at the center of the circular top or bottom of the Cylinder. The effect that creates a Cylinder specifies the radius of the Cylinder’s base and the Cylinder’s height. <br/><br/>A Cylinder’s point of origin is included in the area of effect.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#CylinderAreaofEffect"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#CylinderAreaofEffect"
     },
     {
       "name": "Emanation",
       "summary": "An Emanation is an area of effect that extends in straight lines from a creature or an object in all directions. The effect that creates an Emanation specifies the distance it extends.<br/><br/>An Emanation moves with the creature or object that is its origin unless it is an instantaneous or a stationary effect.<br/><br/>An Emanation’s origin (creature or object) isn’t included in the area of effect unless its creator decides otherwise.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#EmanationAreaofEffect"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#EmanationAreaofEffect"
     },
     {
       "name": "Line",
       "summary": "A Line is an area of effect that extends from a point of origin in a straight path along its length and covers an area defined by its width. The effect that creates a Line specifies its length and width.<br/><br/>A Line’s point of origin isn’t included in the area of effect unless its creator decides otherwise.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#LineAreaofEffect"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#LineAreaofEffect"
     },
     {
       "name": "Sphere",
       "summary": "A Sphere is an area of effect that extends in straight lines from a point of origin outward in all directions. The effect that creates a Sphere specifies the distance it extends as the radius of the Sphere.<br/><br/>A Sphere’s point of origin is included in the Sphere’s area of effect.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#SphereAreaofEffect"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#SphereAreaofEffect"
     }
   ]
 }

--- a/app/data/bonusAction.json
+++ b/app/data/bonusAction.json
@@ -1,12 +1,12 @@
 {
   "title": "Bonus Action",
   "description": "You can take a single Bonus Action on your turn if a rule explicitly says so.",
-  "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#BonusAction",
+  "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#BonusAction",
   "contents": [
     {
-      "name": "Potion of Healing",
-      "summary": "You can drink or administer a potion of healing to another creature within 5 feet of yourself. The creature that drinks the potion regains 2d4 + 2 Hit Points.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/equipment#PotionofHealing50GP"
+      "name": "Use a Potion",
+      "summary": "Drinking a potion or administering it to another creature requires a Bonus Action.",
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/magic-items#Potions"
     }
   ]
 }

--- a/app/data/bonusAction.json
+++ b/app/data/bonusAction.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "Cast a Spell",
-      "summary": "You cast a spell with a casting time of a Bonus Action. Some spells that have a casting time of a Bonus Action are cast in response to a trigger defined in the spell.",
+      "summary": "You cast a spell with a casting time of a Bonus Action, some of which are cast in response to a trigger defined in the spell.",
       "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/spells#ReactionandBonusActionTriggers"
     },
     {

--- a/app/data/bonusAction.json
+++ b/app/data/bonusAction.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "Cast a Spell",
-      "summary": "Cast a spell with a casting time of a Bonus Action.",
+      "summary": "You cast a spell with a casting time of a Bonus Action. Some spells that have a casting time of a Bonus Action are cast in response to a trigger defined in the spell.",
       "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/spells#ReactionandBonusActionTriggers"
     },
     {

--- a/app/data/bonusAction.json
+++ b/app/data/bonusAction.json
@@ -5,7 +5,7 @@
   "contents": [
     {
       "name": "Use a Potion",
-      "summary": "Drinking a potion or administering it to another creature requires a Bonus Action.",
+      "summary": "Drink a potion or administer it to another creature.",
       "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/magic-items#Potions"
     }
   ]

--- a/app/data/bonusAction.json
+++ b/app/data/bonusAction.json
@@ -4,6 +4,16 @@
   "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#BonusAction",
   "contents": [
     {
+      "name": "Attack with a Light Weapon",
+      "summary": "When you take the Attack action with a Light weapon, on the same turn, you can make one extra attack as a Bonus Action with a different Light weapon. This extra attack doesn't add your ability modifier to its damage roll unless the modifier is negative.",
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/equipment#Light"
+    },
+    {
+      "name": "Cast a Spell",
+      "summary": "Cast a spell with a casting time of a Bonus Action.",
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/spells#ReactionandBonusActionTriggers"
+    },
+    {
       "name": "Use a Potion",
       "summary": "Drink a potion or administer it to another creature.",
       "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/magic-items#Potions"

--- a/app/data/conditions.json
+++ b/app/data/conditions.json
@@ -1,82 +1,82 @@
 {
   "title": "Conditions",
   "description": "A condition is a temporary game state. The definition of a condition says how it affects its recipient, and various rules define how to end a condition.",
-  "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#Condition",
+  "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#Condition",
   "contents": [
     {
       "name": "Blinded",
       "summary": "You can’t see and automatically fail any ability check that requires sight, attack rolls against you have Advantage, and your attack rolls have Disadvantage.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#BlindedCondition"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#BlindedCondition"
     },
     {
       "name": "Charmed",
       "summary": "You can’t attack the charmer or target the charmer with damaging abilities or magical effects, and the charmer has Advantage on any ability check to interact with you socially.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#CharmedCondition"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#CharmedCondition"
     },
     {
       "name": "Deafened",
       "summary": "You can’t hear and automatically fail any ability check that requires hearing.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#DeafenedCondition"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#DeafenedCondition"
     },
     {
       "name": "Exhaustion",
       "summary": "You gain 1 Exhaustion level each time you receive this condition. Your D20 Tests are reduced by 2 times your Exhaustion level, and your Speed is reduced by 5 times your Exhaustion level. At Exhaustion level 6, you die. Finishing a Long Rest removes 1 Exhaustion level. At Exhaustion level 0, the condition ends.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#ExhaustionCondition"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#ExhaustionCondition"
     },
     {
       "name": "Frightened",
       "summary": "You have Disadvantage on ability checks and attack rolls while the source of fear is within line of sight, and you can’t willingly move closer to the source of fear.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#FrightenedCondition"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#FrightenedCondition"
     },
     {
       "name": "Grappled",
       "summary": "Your Speed is 0 and can’t increase, you have Disadvantage on attack rolls against any target other than the grappler, and the grappler can drag or carry you when it moves, but every foot of movement costs it 1 extra foot unless you are Tiny or two or more sizes smaller than it.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#GrappledCondition"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#GrappledCondition"
     },
     {
       "name": "Incapacitated",
       "summary": "You can’t take any actions, your Concentration is broken, you can’t speak, and you have Disadvantage on Initiative rolls.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#IncapacitatedCondition"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#IncapacitatedCondition"
     },
     {
       "name": "Invisible",
       "summary": "You have Advantage on Initiative rolls. Additionally, you and any equipment you are wearing or carrying aren’t affected by any effect that requires its target to be seen, attack rolls against you have Disadvantage, and your attack rolls have Advantage, but if a creature can somehow see you, you don’t gain these benefits against that creature.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#InvisibleCondition"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#InvisibleCondition"
     },
     {
       "name": "Paralyzed",
       "summary": "You have the Incapacitated condition, your Speed is 0 and can’t increase, you automatically fail Strength and Dexterity saving throws, attack rolls against you have Advantage, and any attack roll that hits you is a Critical Hit if the attacker is within 5 feet of you.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#ParalyzedCondition"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#ParalyzedCondition"
     },
     {
       "name": "Petrified",
       "summary": "You and any nonmagical objects you are wearing and carrying transformed into a solid inanimate substance, your weight increases by a factor of ten, you cease aging, you have the Incapacitated condition, your Speed is 0 and can’t increase, attack rolls against you have Advantage, you automatically fail Strength and Dexterity saving throws, you have Resistance to all damage, and you have Immunity to the Poisoned condition.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#PetrifiedCondition"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#PetrifiedCondition"
     },
     {
       "name": "Poisoned",
       "summary": "You have Disadvantage on attack rolls and ability checks.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#PoisonedCondition"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#PoisonedCondition"
     },
     {
       "name": "Prone",
       "summary": "You can only move by crawling or by spending an amount of movement equal to half your Speed to right yourself and end the condition (unless your Speed is 0), you have Disadvantage on attack rolls, and attack rolls against you have Advantage if the attacker is within 5 feet of you or Disadvantage if not.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#ProneCondition"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#ProneCondition"
     },
     {
       "name": "Restrained",
       "summary": "Your Speed is 0 and can’t increase, attack rolls against you have Advantage, and you have Disadvantage on attack rolls and Dexterity saving throws.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#RestrainedCondition"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#RestrainedCondition"
     },
     {
       "name": "Stunned",
       "summary": "You have the Incapacitated condition, you automatically fail Strength and Dexterity saving throws, and attack rolls against you have Advantage.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#StunnedCondition"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#StunnedCondition"
     },
     {
       "name": "Unconscious",
       "summary": "You have the Incapacitated and Prone conditions, you drop whatever you’re holding, your Speed is 0 and can’t increase, attack rolls against you have Advantage, you automatically fail Strength and Dexterity saving throws, attack rolls that hit you are Critical Hits if the attacker is within 5 feet of you, and you’re unaware of your surroundings. When this condition ends, you remain Prone.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#UnconsciousCondition"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#UnconsciousCondition"
     }
   ]
 }

--- a/app/data/cover.json
+++ b/app/data/cover.json
@@ -1,7 +1,7 @@
 {
   "title": "Cover",
   "description": "Cover provides a degree of protection to a target behind it. There are three degrees of cover, each of which provides a different benefit to a target. If behind more than one degree of cover, a target benefits only from the most protective degree.",
-  "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#Cover",
+  "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#Cover",
   "contents": [
     {
       "name": "Half Cover",

--- a/app/data/hazards.json
+++ b/app/data/hazards.json
@@ -1,31 +1,31 @@
 {
   "title": "Hazards",
   "description": "A hazard is an environmental danger.",
-  "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#Hazard",
+  "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#Hazard",
   "contents": [
     {
       "name": "Burning",
       "summary": "A burning creature or object takes 1d4 Fire damage at the start of each of its turns. As an action, you can extinguish fire on yourself by giving yourself the Prone condition and rolling on the ground. The fire also goes out if it is doused, submerged, or suffocated.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#BurningHazard"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#BurningHazard"
     },
     {
       "name": "Dehydration",
       "summary": "A creature requires an amount of water per day based on its size, as shown in the Water Needs per Day table. A creature that drinks less than half the required water for a day gains 1 Exhaustion level at the day’s end. Exhaustion caused by dehydration can’t be removed until the creature drinks the full amount of water required for a day.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#DehydrationHazard"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#DehydrationHazard"
     },
     {
       "name": "Falling",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#FallingHazard",
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#FallingHazard",
       "summary": "A creature that falls takes 1d6 Bludgeoning damage at the end of the fall for every 10 feet it fell, to a maximum of 20d6. When the creature lands, it has the Prone condition unless it avoids taking any damage from the fall.<br/><br/>A creature that falls into water or another liquid can use its Reaction to make a DC 15 Strength (Athletics) or Dexterity (Acrobatics) check to hit the surface head or feet first. On a successful check, any damage resulting from the fall is halved."
     },
     {
       "name": "Malnutrition",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#MalnutritionHazard",
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#MalnutritionHazard",
       "summary": "A creature needs an amount of food per day based on its size, as shown in the Food Needs per Day table. A creature that eats but consumes less than half the required food for a day must succeed on a DC 10 Constitution saving throw or gain 1 Exhaustion level at the day’s end. A creature that eats nothing for 5 days automatically gains 1 Exhaustion level at the end of the fifth day as well as an additional level at the end of each subsequent day without food.<br/><br/>Exhaustion caused by malnutrition can’t be removed until the creature eats the full amount of food required for a day. "
     },
     {
       "name": "Suffocation",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#SuffocationHazard",
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#SuffocationHazard",
       "summary": "A creature can hold its breath for a number of minutes equal to 1 plus its Constitution modifier (minimum of 30 seconds) before suffocation begins. When a creature runs out of breath or is choking, it gains 1 Exhaustion level at the end of each of its turns. When a creature can breathe again, it removes all levels of Exhaustion it gained from suffocating."
     }
   ]

--- a/app/data/hazards.json
+++ b/app/data/hazards.json
@@ -16,7 +16,7 @@
     {
       "name": "Falling",
       "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#FallingHazard",
-      "summary": "A creature that falls takes 1d6 Bludgeoning damage at the end of the fall for every 10 feet it fell, to a maximum of 20d6. When the creature lands, it has the Prone condition unless it avoids taking any damage from the fall.<br/><br/>A creature that falls into water or another liquid can use its Reaction to make a DC 15 Strength (Athletics) or Dexterity (Acrobatics) check to hit the surface head or feet first. On a successful check, any damage resulting from the fall is halved."
+      "summary": "A creature that falls takes 1d6 Bludgeoning damage at the end of the fall for every 10 feet it fell, to a maximum of 20d6. When the creature lands, it has the Prone condition unless it avoids taking any damage from the fall. A creature that falls into water or another liquid can use its Reaction to attempt to halve the fall damage (see Reactions > Hit Surface Head or Feet First)."
     },
     {
       "name": "Malnutrition",

--- a/app/data/movement.json
+++ b/app/data/movement.json
@@ -4,6 +4,11 @@
   "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#Speed",
   "contents": [
     {
+      "name": "Burrowing",
+      "summary": "If you have a Burrow Speed, you can use it to move through sand, earth, mud, or ice, but not through solid rock unless you have a trait that allows you to do so.",
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#BurrowSpeed"
+    },
+    {
       "name": "Climbing",
       "summary": "While you’re climbing, each foot of movement costs 1 extra foot (2 extra feet in Difficult Terrain). You ignore this extra cost if you have a Climb Speed and use it to climb.<br/><br/>At the DM’s option, climbing a slippery surface or one with few handholds might require a successful DC 15 Strength (Athletics) check.",
       "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#Climbing"

--- a/app/data/movement.json
+++ b/app/data/movement.json
@@ -1,32 +1,32 @@
 {
   "title": "Movement",
   "description": "On your turn, you can move a distance equal to your Speed or less. Or you can decide not to move. Your movement can include climbing, crawling, jumping, and swimming. These different modes of movement can be combined with your regular movement, or they can constitute your entire move.",
-  "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#Speed",
+  "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#Speed",
   "contents": [
     {
       "name": "Climbing",
       "summary": "While you’re climbing, each foot of movement costs 1 extra foot (2 extra feet in Difficult Terrain). You ignore this extra cost if you have a Climb Speed and use it to climb.<br/><br/>At the DM’s option, climbing a slippery surface or one with few handholds might require a successful DC 15 Strength (Athletics) check.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#Climbing"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#Climbing"
     },
     {
       "name": "Crawling",
       "summary": "While you’re crawling, each foot of movement costs 1 extra foot (2 extra feet in Difficult Terrain).",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#Crawling"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#Crawling"
     },
     {
       "name": "Flying",
       "summary": "A variety of effects allow a creature to fly. While flying, you fall if you have the Incapacitated or Prone condition or your Fly Speed is reduced to 0. You can stay aloft in those circumstances if you can hover.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#Flying"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#Flying"
     },
     {
       "name": "Jumping",
       "summary": "When you jump, you make either a Long Jump (horizontal) or a High Jump (vertical).<br/><br/><strong>Long Jump.</strong> When you make a Long Jump, you leap horizontally a number of feet up to your Strength score if you move at least 10 feet immediately before the jump. When you make a standing Long Jump, you can leap only half that distance. Either way, each foot you jump costs a foot of movement. If you land in Difficult Terrain, you must succeed on a DC 10 Dexterity (Acrobatics) check or have the Prone condition.<br/><br/><strong>High Jump.</strong> When you make a High Jump, you leap into the air a number of feet equal to 3 plus your Strength modifier (minimum of 0 feet) if you move at least 10 feet on foot immediately before the jump. When you make a standing High Jump, you can jump only half that distance. Either way, each foot of the jump costs a foot of movement. You can extend your arms half your height above yourself during the jump. Thus, you can reach a distance equal to the height of the jump plus 1½ times your height.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#Jumping"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#Jumping"
     },
     {
       "name": "Swimming",
       "summary": "While you’re swimming, each foot of movement costs 1 extra foot (2 extra feet in Difficult Terrain). You ignore this extra cost if you have a Swim Speed and use it to swim. At the DM’s option, moving any distance in rough water might require a successful DC 15 Strength (Athletics) check.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#Swimming"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#Swimming"
     }
   ]
 }

--- a/app/data/movement.json
+++ b/app/data/movement.json
@@ -29,9 +29,14 @@
       "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#Flying"
     },
     {
-      "name": "Jumping",
-      "summary": "When you jump, you make either a Long Jump (horizontal) or a High Jump (vertical).<br/><br/><strong>Long Jump.</strong> When you make a Long Jump, you leap horizontally a number of feet up to your Strength score if you move at least 10 feet immediately before the jump. When you make a standing Long Jump, you can leap only half that distance. Either way, each foot you jump costs a foot of movement. If you land in Difficult Terrain, you must succeed on a DC 10 Dexterity (Acrobatics) check or have the Prone condition.<br/><br/><strong>High Jump.</strong> When you make a High Jump, you leap into the air a number of feet equal to 3 plus your Strength modifier (minimum of 0 feet) if you move at least 10 feet on foot immediately before the jump. When you make a standing High Jump, you can jump only half that distance. Either way, each foot of the jump costs a foot of movement. You can extend your arms half your height above yourself during the jump. Thus, you can reach a distance equal to the height of the jump plus 1½ times your height.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#Jumping"
+      "name": "High Jump",
+      "summary": "When you make a High Jump, you leap into the air a number of feet equal to 3 plus your Strength modifier (minimum of 0 feet) if you move at least 10 feet on foot immediately before the jump. When you make a standing High Jump, you can jump only half that distance. Either way, each foot of the jump costs a foot of movement. You can extend your arms half your height above yourself during the jump. Thus, you can reach a distance equal to the height of the jump plus 1½ times your height.",
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#HighJump"
+    },
+    {
+      "name": "Long Jump",
+      "summary": "When you make a Long Jump, you leap horizontally a number of feet up to your Strength score if you move at least 10 feet immediately before the jump. When you make a standing Long Jump, you can leap only half that distance. Either way, each foot you jump costs a foot of movement. If you land in Difficult Terrain, you must succeed on a DC 10 Dexterity (Acrobatics) check or have the Prone condition.",
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#LongJump"
     },
     {
       "name": "Swimming",

--- a/app/data/movement.json
+++ b/app/data/movement.json
@@ -14,6 +14,11 @@
       "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#Crawling"
     },
     {
+      "name": "Dropping Prone",
+      "summary": "On your turn, you can give yourself the Prone condition (see Conditions > Prone) without using an action or your Speed, but you can’t do so if your Speed is 0."
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/playing-the-game#DroppingProne"
+    },
+    {
       "name": "Flying",
       "summary": "A variety of effects allow a creature to fly. While flying, you fall if you have the Incapacitated or Prone condition or your Fly Speed is reduced to 0. You can stay aloft in those circumstances if you can hover.",
       "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#Flying"

--- a/app/data/reaction.json
+++ b/app/data/reaction.json
@@ -9,13 +9,18 @@
       "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/spells#ReactionandBonusActionTriggers"
     },
     {
+      "name": "Hit Surface Head or Feet First",
+      "summary": "In response to falling into water or another liquid (see Hazards > Falling), you make a DC 15 Strength (Athletics) or Dexterity (Acrobatics) check to attempt to hit the surface head or feet first. On a successful check, any damage resulting from the fall is halved.",
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#FallingHazard"
+    },
+    {
       "name": "Opportunity Attack",
       "summary": "When a creature that you can see leaves your reach using an action or one of its speeds, you make one melee attack with a weapon or an Unarmed Strike against the provoking creature. The attack occurs right before the creature leaves your reach.",
       "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#OpportunityAttack"
     },
     {
       "name": "Readied Action or Movement",
-      "summary": "When the trigger of your previous Ready action occurs, you can either take your specified Reaction right after the trigger finishes (which can be an action or moving up to your Speed) or ignore the trigger.",
+      "summary": "When the trigger of your previous Ready action occurs, you can either take your specified Reaction right after the trigger finishes (which can be an action or moving up to your Speed) or ignore the trigger.<br/><br/>To ready a spell, it must have a casting time of an action, and you must maintain Concentration. If your Concentration is broken, the spell dissipates without taking effect.",
       "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#ReadyAction"
     }
   ]

--- a/app/data/reaction.json
+++ b/app/data/reaction.json
@@ -1,17 +1,17 @@
 {
   "title": "Reaction",
   "description": "A Reaction is a special action taken in response to a trigger defined in the Reaction’s description, which you can take on any turn. Once you take a Reaction, you can’t take another one until the start of your next turn.",
-  "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#Reaction",
+  "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#Reaction",
   "contents": [
     {
       "name": "Opportunity Attack",
       "summary": "When a creature that you can see leaves your reach using an action or one of its speeds, you make one melee attack with a weapon or an Unarmed Strike against the provoking creature. The attack occurs right before the creature leaves your reach.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#OpportunityAttack"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#OpportunityAttack"
     },
     {
       "name": "Readied Action or Movement",
       "summary": "When the trigger of your previous Ready action occurs, you can either take your specified Reaction right after the trigger finishes (which can be an action or moving up to your Speed) or ignore the trigger.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#ReadyAction"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#ReadyAction"
     }
   ]
 }

--- a/app/data/reaction.json
+++ b/app/data/reaction.json
@@ -4,6 +4,11 @@
   "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#Reaction",
   "contents": [
     {
+      "name": "Cast a Spell",
+      "summary": "You can cast a spell with a casting time of a Reaction in response to a trigger that is defined in the spell’s Casting Time entry.",
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/spells#ReactionandBonusActionTriggers"
+    },
+    {
       "name": "Opportunity Attack",
       "summary": "When a creature that you can see leaves your reach using an action or one of its speeds, you make one melee attack with a weapon or an Unarmed Strike against the provoking creature. The attack occurs right before the creature leaves your reach.",
       "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#OpportunityAttack"

--- a/app/data/visionAndLight.json
+++ b/app/data/visionAndLight.json
@@ -1,53 +1,53 @@
 {
   "title": "Vision and Light",
   "description": "Some adventuring tasks—such as noticing danger, hitting an enemy, and targeting certain spells—are affected by sight.",
-  "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/playing-the-game#VisionandLight",
+  "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/playing-the-game#VisionandLight",
   "contents": [
     {
       "name": "Darkvision",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#Darkvision",
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#Darkvision",
       "summary": "If you have Darkvision, you can see in Dim Light within a specified range as if it were Bright Light and in Darkness within that range as if it were Dim Light. You discern colors in that Darkness only as shades of gray."
     },
     {
       "name": "Blindsight",
       "summary": "If you have Blindsight, you can see within a specific range without relying on physical sight. Within that range, you can see anything that isn’t behind Total Cover even if you have the Blinded condition or are in Darkness. Moreover, in that range, you can see something that has the Invisible condition.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#senseBlindsightsense"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#senseBlindsightsense"
     },
     {
       "name": "Truesight",
       "summary": "If you have Truesight, your vision is enhanced within a specified range. Within that range, your vision pierces through the following:<br/><br/><strong>Darkness.</strong> You can see in normal and magical Darkness.<br/><br/><strong>Invisibility.</strong> You see creatures and objects that have the Invisible condition.<br/><br/><strong>Visual Illusions.</strong> Visual illusions appear transparent to you, and you automatically succeed on saving throws against them.<br/><br/><strong>Transformations.</strong> You discern the true form of any creature or object you see that has been transformed by magic.<br/><br/><strong>Ethereal Plane.</strong> You see into the Ethereal Plane.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#senseTruesightsense"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#senseTruesightsense"
     },
 
     {
       "name": "Tremorsense",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#senseTremorsensesense",
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#senseTremorsensesense",
       "summary": "A creature with Tremorsense can pinpoint the location of creatures and moving objects within a specific range, provided that the creature with Tremorsense and anything it is detecting are both in contact with the same surface (such as the ground, a wall, or a ceiling) or the same liquid.<br/><br/>Tremorsense can’t detect creatures or objects in the air, and it doesn’t count as a form of sight."
     },
     {
       "name": "Dim Light",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#DimLight",
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#DimLight",
       "summary": "An area with Dim Light is Lightly Obscured."
     },
     {
       "name": "Bright Light",
       "summary": "Bright Light is normal illumination.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#BrightLight"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#BrightLight"
     },
     {
       "name": "Darkness",
       "summary": "An area of Darkness is Heavily Obscured. ",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#Darkness"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#Darkness"
     },
     {
       "name": "Lightly Obscured",
       "summary": "You have Disadvantage on Wisdom (Perception) checks to see something in a Lightly Obscured space.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#LightlyObscured"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#LightlyObscured"
     },
     {
       "name": "Heavily Obscured",
       "summary": "You have the Blinded condition while trying to see something in a Heavily Obscured space.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#HeavilyObscured"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/rules-glossary#HeavilyObscured"
     }
   ]
 }

--- a/app/data/weaponMastery.json
+++ b/app/data/weaponMastery.json
@@ -1,47 +1,47 @@
 {
   "title": "Weapon Mastery",
   "description": "Each weapon has a mastery property, which is usable only by a character who has a feature, such as Weapon Mastery, that unlocks the property for the character. ",
-  "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/equipment#MasteryProperties",
+  "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/equipment#MasteryProperties",
   "contents": [
     {
       "name": "Cleave",
       "summary": "If you hit a creature with a melee attack roll using this weapon, you can make a melee attack roll with the weapon against a second creature within 5 feet of the first that is also within your reach. On a hit, the second creature takes the weapon’s damage, but don’t add your ability modifier to that damage unless that modifier is negative.<br/><br/>You can make this extra attack only once per turn.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/equipment#Cleave"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/equipment#Cleave"
     },
     {
       "name": "Graze",
       "summary": "If your attack roll with this weapon misses a creature, you can deal damage to that creature equal to the ability modifier you used to make the attack roll. This damage is the same type dealt by the weapon, and the damage can be increased only by increasing the ability modifier.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/equipment#Graze"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/equipment#Graze"
     },
     {
       "name": "Nick",
       "summary": "When you make the extra attack of the Light property, you can make it as part of the Attack action instead of as a Bonus Action. You can make this extra attack only once per turn.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/equipment#Nick"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/equipment#Nick"
     },
     {
       "name": "Push",
       "summary": "If you hit a creature with this weapon, you can push the creature up to 10 feet straight away from yourself if it is Large or smaller.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/equipment#Push"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/equipment#Push"
     },
     {
       "name": "Sap",
       "summary": "If you hit a creature with this weapon, that creature has Disadvantage on its next attack roll before the start of your next turn.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/equipment#Sap"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/equipment#Sap"
     },
     {
       "name": "Slow",
       "summary": "If you hit a creature with this weapon and deal damage to it, you can reduce its Speed by 10 feet until the start of your next turn. If the creature is hit more than once by weapons that have this property, the Speed reduction doesn’t exceed 10 feet.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/equipment#Slow"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/equipment#Slow"
     },
     {
       "name": "Topple",
       "summary": "If you hit a creature with this weapon, you can force the creature to make a Constitution saving throw (DC 8 plus the ability modifier used to make the attack roll and your Proficiency Bonus). On a failed save, the creature has the <a href='https://www.dndbeyond.com/sources/dnd/free-rules/rules-glossary#ProneCondition' target='blank'>Prone</a> condition.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/equipment#Topple"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/equipment#Topple"
     },
     {
       "name": "Vex",
       "summary": "If you hit a creature with this weapon and deal damage to the creature, you have Advantage on your next attack roll against that creature before the end of your next turn.",
-      "ddbLink": "https://www.dndbeyond.com/sources/dnd/free-rules/equipment#Vex"
+      "ddbLink": "https://www.dndbeyond.com/sources/dnd/br-2024/equipment#Vex"
     }
   ]
 }


### PR DESCRIPTION
- updated links to point at [new D&D Beyond Basic Rules pages](https://www.dndbeyond.com/sources/dnd/br-2024)
- updated to reflect [2024 Core Rules Errata 2025-04-16](https://www.dndbeyond.com/changelog#2024CoreRulesErrata)
- Actions:
  - separated Unarmed Strike damage, grapple, and shove options from Attack (Weapon) action
  - updated Hide action to include fixed DC, the Invisible condition, and how to be found or no longer be hidden
  - updated Utilize action to include donning or doffing a Shield
- Bonus Actions:
  - added Bonus Action options: Attack with a Light Weapon, Cast a Spell
  - changed Potion of Healing Bonus Action to note that it applies to all potions
- Hazards:
  - moved reaction to halve fall damage to Reactions
- Movement:
  - added Movement options: Burrowing, Dropping Prone
  - split Jumping into Long Jump and High Jump
- Reactions:
  - added Reaction options: Cast a Spell, Hit Surface Head or Feet First
   - updated Readied Action or Movement to note Concentration requirement when casting a spell